### PR TITLE
Fix num_classes in feature_extractor to avoid confusion

### DIFF
--- a/feature_extractors/auditory_slowfast/configs/AVE/SLOWFAST_R50.yaml
+++ b/feature_extractors/auditory_slowfast/configs/AVE/SLOWFAST_R50.yaml
@@ -44,7 +44,7 @@ SOLVER:
   WARMUP_START_LR: 0.01
   OPTIMIZING_METHOD: sgd
 MODEL:
-  NUM_CLASSES: 28
+  NUM_CLASSES: [28]
   ARCH: slowfast
   MODEL_NAME: SlowFast
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/auditory_slowfast/configs/AVE/SLOWFAST_R50.yaml
+++ b/feature_extractors/auditory_slowfast/configs/AVE/SLOWFAST_R50.yaml
@@ -44,7 +44,7 @@ SOLVER:
   WARMUP_START_LR: 0.01
   OPTIMIZING_METHOD: sgd
 MODEL:
-  NUM_CLASSES: [97,300]
+  NUM_CLASSES: 28
   ARCH: slowfast
   MODEL_NAME: SlowFast
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/auditory_slowfast/configs/EPIC-SOUNDS/SLOWFAST_R50.yaml
+++ b/feature_extractors/auditory_slowfast/configs/EPIC-SOUNDS/SLOWFAST_R50.yaml
@@ -42,7 +42,7 @@ SOLVER:
   WARMUP_START_LR: 0.01
   OPTIMIZING_METHOD: sgd
 MODEL:
-  NUM_CLASSES: [97, 300]
+  NUM_CLASSES: 44
   ARCH: slowfast
   MODEL_NAME: SlowFast
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/auditory_slowfast/configs/EPIC-SOUNDS/SLOWFAST_R50.yaml
+++ b/feature_extractors/auditory_slowfast/configs/EPIC-SOUNDS/SLOWFAST_R50.yaml
@@ -42,7 +42,7 @@ SOLVER:
   WARMUP_START_LR: 0.01
   OPTIMIZING_METHOD: sgd
 MODEL:
-  NUM_CLASSES: 44
+  NUM_CLASSES: [44]
   ARCH: slowfast
   MODEL_NAME: SlowFast
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/auditory_slowfast/configs/PERCEPTION/SLOWFAST_R50.yaml
+++ b/feature_extractors/auditory_slowfast/configs/PERCEPTION/SLOWFAST_R50.yaml
@@ -45,7 +45,7 @@ SOLVER:
   WARMUP_START_LR: 0.01
   OPTIMIZING_METHOD: sgd
 MODEL:
-  NUM_CLASSES: [97, 300]
+  NUM_CLASSES: 67
   ARCH: slowfast
   MODEL_NAME: SlowFast
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/auditory_slowfast/configs/PERCEPTION/SLOWFAST_R50.yaml
+++ b/feature_extractors/auditory_slowfast/configs/PERCEPTION/SLOWFAST_R50.yaml
@@ -45,7 +45,7 @@ SOLVER:
   WARMUP_START_LR: 0.01
   OPTIMIZING_METHOD: sgd
 MODEL:
-  NUM_CLASSES: 67
+  NUM_CLASSES: [67]
   ARCH: slowfast
   MODEL_NAME: SlowFast
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/auditory_slowfast/tools/test_net.py
+++ b/feature_extractors/auditory_slowfast/tools/test_net.py
@@ -46,6 +46,7 @@ def perform_test(test_loader, model, test_meter, cfg):
 
         if isinstance(labels, (dict,)):
             # Gather all the predictions across all the devices to perform ensemble.
+            # You don't need to use preds or labels but just in case if you want to evaluate the model, we'll keep it.
             if cfg.NUM_GPUS > 1:
                 verb_preds, verb_labels, audio_idx = du.all_gather(
                     [preds[0], labels['verb'], audio_idx]
@@ -53,6 +54,9 @@ def perform_test(test_loader, model, test_meter, cfg):
 
                 noun_preds, noun_labels, audio_idx = du.all_gather(
                     [preds[1], labels['noun'], audio_idx]
+                )
+                feature, audio_idx = du.all_gather(
+                    [feature, audio_idx]
                 )
                 meta = du.all_gather_unaligned(meta)
                 metadata = {'narration_id': []}
@@ -69,6 +73,7 @@ def perform_test(test_loader, model, test_meter, cfg):
                 noun_preds = noun_preds.cpu()
                 noun_labels = noun_labels.cpu()
                 audio_idx = audio_idx.cpu()
+                feature = feature.cpu()
 
             test_meter.iter_toc()
 

--- a/feature_extractors/omnivore/configs/AVE/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/AVE/OMNIVORE_feature.yaml
@@ -8,7 +8,6 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
-  NUM_CLASSES: 28
   ARCH: omnivore_swinB
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/omnivore/configs/AVE/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/AVE/OMNIVORE_feature.yaml
@@ -8,12 +8,12 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
-  NUM_CLASSES: [97, 300]
   ARCH: omnivore_swinB
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy
   DROPOUT_RATE: 0.5
 TEST:
+  NUM_CLASSES: 28
   ENABLE: True
   DATASET: ave
   BATCH_SIZE: 4

--- a/feature_extractors/omnivore/configs/AVE/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/AVE/OMNIVORE_feature.yaml
@@ -8,12 +8,12 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
+  NUM_CLASSES: 28
   ARCH: omnivore_swinB
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy
   DROPOUT_RATE: 0.5
 TEST:
-  NUM_CLASSES: 28
   ENABLE: True
   DATASET: ave
   BATCH_SIZE: 4

--- a/feature_extractors/omnivore/configs/EPIC-KITCHENS/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/EPIC-KITCHENS/OMNIVORE_feature.yaml
@@ -8,12 +8,12 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
+  NUM_CLASSES: [97, 300]
   ARCH: omnivore_swinB_epic
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy
   DROPOUT_RATE: 0.5
 TEST:
-  NUM_CLASSES: [97, 300]
   ENABLE: True
   DATASET: epickitchens
   BATCH_SIZE: 4

--- a/feature_extractors/omnivore/configs/EPIC-KITCHENS/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/EPIC-KITCHENS/OMNIVORE_feature.yaml
@@ -8,7 +8,6 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
-  NUM_CLASSES: [97, 300]
   ARCH: omnivore_swinB_epic
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/omnivore/configs/EPIC-KITCHENS/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/EPIC-KITCHENS/OMNIVORE_feature.yaml
@@ -8,12 +8,12 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
-  NUM_CLASSES: [97, 300]
   ARCH: omnivore_swinB_epic
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy
   DROPOUT_RATE: 0.5
 TEST:
+  NUM_CLASSES: [97, 300]
   ENABLE: True
   DATASET: epickitchens
   BATCH_SIZE: 4

--- a/feature_extractors/omnivore/configs/PERCEPTION_TEST/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/PERCEPTION_TEST/OMNIVORE_feature.yaml
@@ -8,12 +8,12 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
+  NUM_CLASSES: 67
   ARCH: omnivore_swinB
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy
   DROPOUT_RATE: 0.5
 TEST:
-  NUM_CLASSES: 67
   ENABLE: True
   DATASET: perception
   BATCH_SIZE: 2

--- a/feature_extractors/omnivore/configs/PERCEPTION_TEST/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/PERCEPTION_TEST/OMNIVORE_feature.yaml
@@ -8,12 +8,12 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
-  NUM_CLASSES: [97, 300]
   ARCH: omnivore_swinB
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy
   DROPOUT_RATE: 0.5
 TEST:
+  NUM_CLASSES: 67
   ENABLE: True
   DATASET: perception
   BATCH_SIZE: 2

--- a/feature_extractors/omnivore/configs/PERCEPTION_TEST/OMNIVORE_feature.yaml
+++ b/feature_extractors/omnivore/configs/PERCEPTION_TEST/OMNIVORE_feature.yaml
@@ -8,7 +8,6 @@ DATA:
   FRAME_SAMPLING: 'like omnivore'
   USE_RAND_AUGMENT: True
 MODEL:
-  NUM_CLASSES: 67
   ARCH: omnivore_swinB
   MODEL_NAME: Omnivore
   LOSS_FUNC: cross_entropy

--- a/feature_extractors/omnivore/omnivore/utils/multiprocessing.py
+++ b/feature_extractors/omnivore/omnivore/utils/multiprocessing.py
@@ -45,6 +45,6 @@ def run(
         )
     except Exception as e:
         raise e
-    print(local_rank)
+
     torch.cuda.set_device(local_rank)
     func(cfg)

--- a/feature_extractors/omnivore/omnivore/utils/multiprocessing.py
+++ b/feature_extractors/omnivore/omnivore/utils/multiprocessing.py
@@ -45,6 +45,6 @@ def run(
         )
     except Exception as e:
         raise e
-
+    print(local_rank)
     torch.cuda.set_device(local_rank)
     func(cfg)


### PR DESCRIPTION
I deleted NUM_CLASSES in omnivore and changed the NUM_CLASSES in auditory_slowfast.
Those are not used since the model does not use cls_head for feature extraction.